### PR TITLE
#3 setting active organization now retrives role from role-specific pages

### DIFF
--- a/fitness-appc3005/src/app/member/page.tsx
+++ b/fitness-appc3005/src/app/member/page.tsx
@@ -37,8 +37,7 @@ export default async function Members() {
     headers: await headers()
   })
   const role = roleData?.role;
-  console.log("Member role:", role);
-  console.log("Active organization ID:", session.activeOrganizationId);
+
 
   const sessions = await getSessions();
 

--- a/fitness-appc3005/src/app/signup/Verify.tsx
+++ b/fitness-appc3005/src/app/signup/Verify.tsx
@@ -44,6 +44,7 @@ export default function Verify({ email }: { email: string }) {
 
         await authClient.sendVerificationEmail({
             email,
+            callbackURL: "/member",
         }, {
             onSuccess: () => {
                 setSent(true);

--- a/fitness-appc3005/src/lib/auth-client.ts
+++ b/fitness-appc3005/src/lib/auth-client.ts
@@ -1,10 +1,8 @@
 import { createAuthClient } from "better-auth/react";
 import { nextCookies } from "better-auth/next-js";
-import { organizationClient } from "better-auth/client/plugins";
-import { organization } from "better-auth/plugins";
 export const authClient = createAuthClient({
   //Later will use NEXT_PUBLIC_BETTER_AUTH_URL from .env.
   //When in prod
   baseURL: process.env.NEXT_PUBLIC_BETTER_AUTH_URL || "http://localhost:3000",
-  plugins: [nextCookies(), organizationClient(), organization()],
+  plugins: [nextCookies()],
 });

--- a/fitness-appc3005/src/lib/auth.ts
+++ b/fitness-appc3005/src/lib/auth.ts
@@ -6,7 +6,6 @@ import { PrismaPg } from "@prisma/adapter-pg";
 import { Resend } from "resend";
 import { EmailTemplate } from "../components/EmailTemplate";
 import { organization } from "better-auth/plugins";
-import { organizationClient } from "better-auth/client/plugins";
 
 const resend = new Resend(process.env.RESEND_API_KEY);
 
@@ -18,7 +17,7 @@ const prisma = new PrismaClient({ adapter });
 
 export const auth = betterAuth({
   //Needed if accessing organization data server-side
-  plugins: [organization(), organizationClient()],
+  plugins: [organization()],
   baseURL: process.env.NEXT_PUBLIC_BETTER_AUTH_URL || "http://localhost:3000",
   secret: process.env.BETTER_AUTH_SECRET!,
   database: prismaAdapter(prisma, {


### PR DESCRIPTION


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication/session creation by writing `activeOrganizationId` into sessions and enabling organization plugins, which can affect login/session behavior if misconfigured or if member/org data is missing.
> 
> **Overview**
> Adds Better Auth organization plugins to both the client (`authClient`) and server (`auth`) configuration.
> 
> On session creation, a new `databaseHooks.session.create.before` hook looks up the user’s `Member.organizationId` and persists it into the session’s `activeOrganizationId`, enabling role/org-aware server-side flows.
> 
> Updates the member hub page to use server-side `getActiveMemberRole()` (and log role/org ID) and removes the verification email resend `callbackURL` override; Prisma changes are comment-only (seed note and index comment move).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3c53c4900319d43e244fbd60a69f97224e6a1284. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->