### PR TITLE
Added rate limits to API routes/pages

### DIFF
--- a/fitness/src/app/api/member/search/route.ts
+++ b/fitness/src/app/api/member/search/route.ts
@@ -1,7 +1,30 @@
 import prisma from "@/lib/prisma";
+import { getSession } from "@/lib/actions";
+import { getActiveMemberRole } from "@/lib/actions";
 /*Member Search Functionality in Trainers tab*/
 export async function POST(req: Request) {
   try {
+    const session = await getSession();
+    const activeMemberRole = await getActiveMemberRole();
+    if (!session) {
+      return new Response(JSON.stringify({ error: "Unauthorized" }), {
+        status: 401,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    if (activeMemberRole !== "trainer") {
+      return new Response(
+        JSON.stringify({
+          error: "You do not have the role of trainer to access this page.",
+        }),
+        {
+          status: 401,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
+    }
+
     const { name } = await req.json(); // parse JSON from request body
     if (!name) {
       return new Response(JSON.stringify([]), {

--- a/fitness/src/app/api/trainer/search/route.ts
+++ b/fitness/src/app/api/trainer/search/route.ts
@@ -1,7 +1,30 @@
 import prisma from "@/lib/prisma";
+import { getSession } from "@/lib/actions";
+import { getActiveMemberRole } from "@/lib/actions";
 /*Filters Sessions by Trainer*/
 export async function POST(req: Request) {
   try {
+    const session = await getSession();
+    const activeMemberRole = await getActiveMemberRole();
+    if (!session) {
+      return new Response(JSON.stringify({ error: "Unauthorized" }), {
+        status: 401,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    if (activeMemberRole !== "trainer") {
+      return new Response(
+        JSON.stringify({
+          error: "You do not have the role of trainer to access this page.",
+        }),
+        {
+          status: 401,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
+    }
+
     const { id } = await req.json(); // parse JSON from request body
     if (!id) {
       const sessions = await prisma.classSession.findMany({

--- a/fitness/src/app/member/(components)/ProfileManagement.tsx
+++ b/fitness/src/app/member/(components)/ProfileManagement.tsx
@@ -20,11 +20,17 @@ import { toast } from "sonner";
 import { Loader } from "@/components/ui/loader";
 
 // Helper: Transform empty strings to undefined, then validate
-const optionalString = z.string().transform(val => val.trim() === "" ? undefined : val).optional();
-const optionalEmail = z.string().transform(val => val.trim() === "" ? undefined : val)
-  .refine(val => val === undefined || z.email().safeParse(val).success, {
+const optionalString = z
+  .string()
+  .transform((val) => (val.trim() === "" ? undefined : val))
+  .optional();
+const optionalEmail = z
+  .string()
+  .transform((val) => (val.trim() === "" ? undefined : val))
+  .refine((val) => val === undefined || z.email().safeParse(val).success, {
     message: "Invalid email address",
-  }).optional();
+  })
+  .optional();
 
 const formSchema = z.object({
   firstName: optionalString,
@@ -35,14 +41,25 @@ const formSchema = z.object({
 type FormData = z.infer<typeof formSchema>;
 
 const fitnessFormSchema = z.object({
-  currWeight: z.number().min(1, { message: "Current weight is required" }).max(999, { message: "Current weight must be less than 999" }),
-  weightTarget: z.number().min(1, { message: "Weight target is required" }).max(999, { message: "Weight target must be less than 999" }),
+  currWeight: z
+    .number()
+    .min(1, { message: "Current weight is required" })
+    .max(999, { message: "Current weight must be less than 999" }),
+  weightTarget: z
+    .number()
+    .min(1, { message: "Weight target is required" })
+    .max(999, { message: "Weight target must be less than 999" }),
 });
 
 type FitnessFormData = z.infer<typeof fitnessFormSchema>;
 
-export const ProfileManagement = ({ userId, memberId }: { userId: string, memberId: number }) => {
-
+export const ProfileManagement = ({
+  userId,
+  memberId,
+}: {
+  userId: string;
+  memberId: number;
+}) => {
   const form = useForm<FormData>({
     resolver: zodResolver(formSchema),
     defaultValues: {
@@ -83,7 +100,9 @@ export const ProfileManagement = ({ userId, memberId }: { userId: string, member
         form.setError("root.serverError", { message: error.message });
         toast.error(error.message);
       } else {
-        form.setError("root.serverError", { message: "Failed to update profile details" });
+        form.setError("root.serverError", {
+          message: "Failed to update profile details",
+        });
         toast.error("Failed to update profile details");
       }
     }
@@ -99,13 +118,14 @@ export const ProfileManagement = ({ userId, memberId }: { userId: string, member
     try {
       await updateMetrics(formData);
       toast.success("Fitness details updated successfully");
-      fitnessForm.reset();
     } catch (error: unknown) {
       if (error instanceof Error) {
         fitnessForm.setError("root.serverError", { message: error.message });
         toast.error(error.message);
       } else {
-        fitnessForm.setError("root.serverError", { message: "Failed to update fitness details" });
+        fitnessForm.setError("root.serverError", {
+          message: "Failed to update fitness details",
+        });
         toast.error("Failed to update fitness details");
       }
     }
@@ -115,12 +135,17 @@ export const ProfileManagement = ({ userId, memberId }: { userId: string, member
     <Card className="w-full xl:max-w-xl lg:max-w-md sm:max-w-sm max-w-xs mb-5">
       <CardHeader>
         <CardTitle className="flex gap-2 items-center">
-          <span style={{ fontFamily: "var(--font-display)" }} className="font-black uppercase tracking-wide text-2xl leading-none">
+          <span
+            style={{ fontFamily: "var(--font-display)" }}
+            className="font-black uppercase tracking-wide text-2xl leading-none"
+          >
             Profile Management
           </span>
           <IconUserScan className="text-primary" />
         </CardTitle>
-        <CardDescription className="text-xs tracking-wider uppercase">Update your details/fitness goals</CardDescription>
+        <CardDescription className="text-xs tracking-wider uppercase">
+          Update your details/fitness goals
+        </CardDescription>
       </CardHeader>
 
       <CardContent>
@@ -130,21 +155,37 @@ export const ProfileManagement = ({ userId, memberId }: { userId: string, member
           <div className="flex flex-col gap-4">
             <div className="flex flex-col gap-1">
               <div className="flex items-center gap-3">
-                <span className="text-xs font-mono font-bold tracking-wider text-primary/60">01</span>
+                <span className="text-xs font-mono font-bold tracking-wider text-primary/60">
+                  01
+                </span>
                 <div className="h-px flex-1 bg-border/60" />
               </div>
-              <CardTitle className="text-sm font-bold tracking-widest uppercase">Personal Details</CardTitle>
-              <CardDescription>All fields optional - update what you want to change.</CardDescription>
+              <CardTitle className="text-sm font-bold tracking-widest uppercase">
+                Personal Details
+              </CardTitle>
+              <CardDescription>
+                All fields optional - update what you want to change.
+              </CardDescription>
             </div>
 
             {/* Error message for server errors (Personal Details)*/}
             {form.formState.errors.root?.serverError && (
-              <p className="text-xs text-red-500">{form.formState.errors.root.serverError.message}</p>
+              <p className="text-xs text-red-500">
+                {form.formState.errors.root.serverError.message}
+              </p>
             )}
 
-            <Input {...form.register("email")} id="email" type="email" name="email" placeholder="Email" />
+            <Input
+              {...form.register("email")}
+              id="email"
+              type="email"
+              name="email"
+              placeholder="Email"
+            />
             {form.formState.errors.email && (
-              <p className="text-xs text-red-500">{form.formState.errors.email.message}</p>
+              <p className="text-xs text-red-500">
+                {form.formState.errors.email.message}
+              </p>
             )}
             <Input
               {...form.register("firstName")}
@@ -154,7 +195,9 @@ export const ProfileManagement = ({ userId, memberId }: { userId: string, member
               placeholder="First Name"
             />
             {form.formState.errors.firstName && (
-              <p className="text-xs text-red-500">{form.formState.errors.firstName.message}</p>
+              <p className="text-xs text-red-500">
+                {form.formState.errors.firstName.message}
+              </p>
             )}
             <Input
               {...form.register("lastName")}
@@ -164,10 +207,16 @@ export const ProfileManagement = ({ userId, memberId }: { userId: string, member
               placeholder="Last Name"
             />
             {form.formState.errors.lastName && (
-              <p className="text-xs text-red-500">{form.formState.errors.lastName.message}</p>
+              <p className="text-xs text-red-500">
+                {form.formState.errors.lastName.message}
+              </p>
             )}
           </div>
-          <Button type="submit" className="w-full mt-4 cursor-pointer" variant="secondary">
+          <Button
+            type="submit"
+            className="w-full mt-4 cursor-pointer"
+            variant="secondary"
+          >
             Update
             {form.formState.isSubmitting ? <Loader /> : null}
           </Button>
@@ -177,16 +226,24 @@ export const ProfileManagement = ({ userId, memberId }: { userId: string, member
           <div className="flex flex-col gap-4 my-4">
             <div className="flex flex-col gap-1">
               <div className="flex items-center gap-3">
-                <span className="text-xs font-mono font-bold tracking-wider text-primary/60">02</span>
+                <span className="text-xs font-mono font-bold tracking-wider text-primary/60">
+                  02
+                </span>
                 <div className="h-px flex-1 bg-border/60" />
               </div>
-              <CardTitle className="text-sm font-bold tracking-widest uppercase">Fitness Details</CardTitle>
-              <CardDescription>All fields required - please enter both fields.</CardDescription>
+              <CardTitle className="text-sm font-bold tracking-widest uppercase">
+                Fitness Details
+              </CardTitle>
+              <CardDescription>
+                All fields required - please enter both fields.
+              </CardDescription>
             </div>
 
             {/* Error message for server errors (Fitness Details)*/}
             {fitnessForm.formState.errors.root?.serverError && (
-              <p className="text-xs text-red-500">{fitnessForm.formState.errors.root.serverError.message}</p>
+              <p className="text-xs text-red-500">
+                {fitnessForm.formState.errors.root.serverError.message}
+              </p>
             )}
 
             <Label htmlFor="currWeight">Current Weight</Label>
@@ -200,7 +257,9 @@ export const ProfileManagement = ({ userId, memberId }: { userId: string, member
               required={true}
             />
             {fitnessForm.formState.errors.currWeight && (
-              <p className="text-xs text-red-500">{fitnessForm.formState.errors.currWeight.message}</p>
+              <p className="text-xs text-red-500">
+                {fitnessForm.formState.errors.currWeight.message}
+              </p>
             )}
             <Label htmlFor="weightTarget"> Weight Target (lbs)</Label>
             <Input
@@ -213,7 +272,9 @@ export const ProfileManagement = ({ userId, memberId }: { userId: string, member
               required={true}
             />
             {fitnessForm.formState.errors.weightTarget && (
-              <p className="text-xs text-red-500">{fitnessForm.formState.errors.weightTarget.message}</p>
+              <p className="text-xs text-red-500">
+                {fitnessForm.formState.errors.weightTarget.message}
+              </p>
             )}
           </div>
           <Button type="submit" className="w-full cursor-pointer">
@@ -225,4 +286,4 @@ export const ProfileManagement = ({ userId, memberId }: { userId: string, member
       <CardFooter className="flex-col"></CardFooter>
     </Card>
   );
-}
+};

--- a/fitness/src/components/SessionGuard.tsx
+++ b/fitness/src/components/SessionGuard.tsx
@@ -15,8 +15,9 @@ export const SessionGuard = () => {
         if (error) {
             toast.error(`Failed to get session: ${error.message}`);
         }
-        // Only redirect after session check is complete
-        if (!isPending && !session) {
+        // Only redirect when the check definitively returned no session
+        // If there's an error (e.g. rate limit), don't assume unauthenticated
+        if (!isPending && !session && !error) {
             router.push("/signin");
         }
     }, [session, isPending, router, error]);

--- a/fitness/src/lib/actions.ts
+++ b/fitness/src/lib/actions.ts
@@ -380,6 +380,28 @@ export const updateMetrics = async (formData: FormData): Promise<void> => {
   const weightGoal = formData.get("weightTarget");
   const metricUpdateData: any = {};
 
+  const COOLDOWN_MINUTES = 1;
+
+  //Finds most recent metric for the member and grabs only the timestamp field
+  const lastMetric = await prisma.healthMetric.findFirst({
+    where: {
+      memberId: Number(memberId),
+    },
+    orderBy: {
+      timestamp: "desc",
+    },
+    select: {
+      timestamp: true,
+    },
+  });
+
+  if (lastMetric) {
+    const minutesSince = (Date.now() - lastMetric.timestamp.getTime()) / 60000;
+    if (minutesSince < COOLDOWN_MINUTES) {
+      throw new Error("You must wait 1 minute between updating your metrics");
+    }
+  }
+
   if (weight) metricUpdateData.weight = Number(weight);
   if (weightGoal) metricUpdateData.weightGoal = Number(weightGoal);
 
@@ -409,6 +431,30 @@ export const registerSessions = async (
 ): Promise<{ success: boolean; error?: string }> => {
   const ids = formData.getAll("sessionIds") as string[];
   const memberId = formData.get("memberId") as string;
+
+  const COOLDOWN_MINUTES = 1;
+
+  const lastBooking = await prisma.booking.findFirst({
+    where: {
+      memberId: Number(memberId),
+    },
+    orderBy: {
+      createdAt: "desc",
+    },
+    select: {
+      createdAt: true,
+    },
+  });
+
+  if (lastBooking) {
+    const minutesSince = (Date.now() - lastBooking.createdAt.getTime()) / 60000;
+    if (minutesSince < COOLDOWN_MINUTES) {
+      return {
+        success: false,
+        error: "You must wait 1 minute between booking sessions",
+      };
+    }
+  }
 
   if (ids.length === 0) return { success: true };
   try {

--- a/fitness/src/lib/auth-client.ts
+++ b/fitness/src/lib/auth-client.ts
@@ -17,4 +17,13 @@ export const authClient = createAuthClient({
     }),
     nextCookies(),
   ],
+  fetchOptions: {
+    onError: async (context) => {
+      const { response } = context;
+      if (response.status === 429) {
+        const retryAfter = response.headers.get("X-Retry-After");
+        console.log(`Rate limit exceeded. Retry after ${retryAfter} seconds`);
+      }
+    },
+  },
 });

--- a/fitness/src/lib/auth.ts
+++ b/fitness/src/lib/auth.ts
@@ -38,6 +38,38 @@ export const auth = betterAuth({
       clientSecret: process.env.GOOGLE_CLIENT_SECRET as string,
     },
   },
+  rateLimit: {
+    enabled: true,
+    max: 25, //25 requests per minute
+    window: 60, //1 min,
+    customRules: {
+      // Session checks happen on every page load - exempt from the low global limit
+      "/get-session": {
+        max: 150,
+        window: 60,
+      },
+      "/sign-in/social": {
+        max: 3,
+        window: 60,
+      },
+      "/sign-in/email": {
+        max: 3,
+        window: 60,
+      },
+      "/sign-up/email": {
+        max: 3,
+        window: 60,
+      },
+      "/send-verification-email": {
+        max: 3,
+        window: 60,
+      },
+      "/change-password": {
+        max: 3,
+        window: 60,
+      },
+    },
+  },
   //This links Google accounts to those who originally signed up with email and password
   account: {
     accountLinking: {


### PR DESCRIPTION
Added rate limits for: 

- API routes - covered through BetterAuth when calling getSession (API routes are also checking for session & correct roles now)
- Signin, signup, verification email & password change operations (max of 3 requests/min)
- Session retrieval (capped at 150/minute)
- Otherwise for any other auth operation, 25 requests/minute 
- updateMetrics and registerSessions server actions (retrieves the most recent entry and compares the date of creation to the curr. date)