### PR TITLE
Added base64urlencoding session cache

### DIFF
--- a/fitness/src/app/Homepage.tsx
+++ b/fitness/src/app/Homepage.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React, { useState, useEffect, useSyncExternalStore } from "react";
+import { useState, useEffect, useSyncExternalStore } from "react";
 import { FaUser } from "react-icons/fa";
 import { IoMdFitness } from "react-icons/io";
 import { RiAdminFill } from "react-icons/ri";
@@ -48,15 +48,17 @@ const UserPill = ({ user, text, selected, onClick, index }: userPillProps) => {
         ${
           selected
             ? "bg-primary border-primary text-primary-foreground"
-            : "bg-transparent border-border/60 text-muted-foreground hover:border-primary/60 hover:text-foreground"
+            : "bg-transparent border-border/60  hover:border-primary/60 hover:text-foreground"
         }
       `}
     >
-      <span className="text-xs font-mono font-bold tracking-wider text-white">
+      <span className={`text-xs font-mono font-bold tracking-wider`}>
         0{index + 1}
       </span>
       <Icon />
-      <span className="text-white text-xs sm:text-sm font-bold tracking-widest uppercase whitespace-nowrap">
+      <span
+        className={`text-xs sm:text-sm font-bold tracking-widest uppercase whitespace-nowrap`}
+      >
         {text}
       </span>
     </button>

--- a/fitness/src/lib/auth.ts
+++ b/fitness/src/lib/auth.ts
@@ -89,13 +89,12 @@ export const auth = betterAuth({
     Tradeoffs:
     - Don't need to hit the database everytime for session data
     - However, no immediate invalidation of sessions
-    
+    */
     cookieCache: {
       enabled: true,
       maxAge: 60, //1 minute
-      strategy: "jwt",
+      strategy: "compact",
     },
-    */
     // 1 day
     expiresIn: 60 * 60 * 24,
     updateAge: 60 * 60 * 24, // Extend session by 1 day


### PR DESCRIPTION
Enabled cookieCache in BetterAuth spec - allows session cache to be stored to prevent DB hits on every session grab. Opted to use "compact" - which uses no JWT overhead spec but rather one base64url encoding with a signature in case of tampering.

For comparison, JWT's have 3 base64url parts while JWE's has 5 (to protect the payload data as well)

Interval is set to 60 seconds

Downside is no instant session revocation - although considering this is more of a personal project, performance takes priority for now. 

Also changed a few styling classNames in the homepage to help make userPill fonts more visible (esp in light mode)